### PR TITLE
Update APIs for React ^16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,8 @@
     "prepare": "yarn run clean && yarn run build"
   },
   "lint-staged": {
-    "src/**/*.js": [
-      "prettier --write --single-quote",
-      "git add"
-    ],
-    "test/**/*.js": [
-      "prettier --write --single-quote",
-      "git add"
-    ]
+    "src/**/*.js": ["prettier --write --single-quote", "git add"],
+    "test/**/*.js": ["prettier --write --single-quote", "git add"]
   },
   "repository": {
     "type": "git",
@@ -38,15 +32,8 @@
   "bugs": {
     "url": "https://github.com/jdlehman/switcheroo/issues"
   },
-  "keywords": [
-    "react",
-    "react-component",
-    "routing",
-    "javascript"
-  ],
-  "files": [
-    "dist"
-  ],
+  "keywords": ["react", "react-component", "routing", "javascript"],
+  "files": ["dist"],
   "author": "Jonathan Lehman <jonathan.lehman91@gmail.com>",
   "license": "MIT",
   "devDependencies": {
@@ -71,9 +58,9 @@
     "jsdom": "^12.2.0",
     "lint-staged": "^7.2.0",
     "prettier": "^1.3.1",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
-    "react-test-renderer": "^16.0.0",
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0",
+    "react-test-renderer": "^16.3.0",
     "rollup": "^0.66.6",
     "rollup-plugin-babel": "^4.0.3",
     "rollup-plugin-commonjs": "^9.1.5",
@@ -83,7 +70,7 @@
     "uglify-js": "^3.0.4"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
+    "react": "^16.3.0"
   },
   "dependencies": {
     "prop-types": "^15.5.10"

--- a/src/SwitcherConsumer.js
+++ b/src/SwitcherConsumer.js
@@ -1,0 +1,58 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Consumer } from './listenerContext';
+import Switcher from './Switcher';
+
+export default class SwitcherConsumer extends Component {
+  static propTypes = {
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
+    ]),
+    pushState: PropTypes.bool,
+    hashChange: PropTypes.bool,
+    load: PropTypes.bool,
+    onChange: PropTypes.func,
+    wrapper: PropTypes.any,
+    location: PropTypes.string,
+    basePath: PropTypes.string,
+    preventUpdate: PropTypes.func,
+    mapDynamicSegments: PropTypes.func,
+    renderSwitch: PropTypes.func
+  };
+
+  static defaultProps = {
+    pushState: false,
+    hashChange: true,
+    load: true,
+    location: 'hash',
+    basePath: '',
+    preventUpdate: () => false,
+    mapDynamicSegments: values => values
+  };
+
+  render() {
+    return (
+      <Consumer>
+        {({
+          usingProvider,
+          addLoadListener,
+          addPopStateListener,
+          addHashChangeListener,
+          removeListeners
+        }) => {
+          return (
+            <Switcher
+              {...this.props}
+              usingProvider={usingProvider}
+              addLoadListener={addLoadListener}
+              addPopStateListener={addPopStateListener}
+              addHashChangeListener={addHashChangeListener}
+              removeListeners={removeListeners}
+            />
+          );
+        }}
+      </Consumer>
+    );
+  }
+}

--- a/src/SwitcherProvider.js
+++ b/src/SwitcherProvider.js
@@ -1,23 +1,13 @@
 import React, { Children, Component } from 'react';
 import PropTypes from 'prop-types';
+import { Provider, createListenerContext } from './listenerContext';
 
 export default class SwitcherProvider extends Component {
   static displayName = 'SwitcherProvider';
 
-  static propTypes = {
-    children: PropTypes.node
-  };
-
-  static childContextTypes = {
-    switcherProvider: PropTypes.shape({
-      loadListeners: PropTypes.array.isRequired,
-      popStateListeners: PropTypes.array.isRequired,
-      hashChangeListeners: PropTypes.array.isRequired
-    })
-  };
-
-  getChildContext() {
-    return { switcherProvider: this.switcherProvider };
+  constructor(props) {
+    super(props);
+    this._listenerContext = createListenerContext(true);
   }
 
   componentDidMount() {
@@ -32,29 +22,29 @@ export default class SwitcherProvider extends Component {
     window.removeEventListener('hashchange', this.handleHashChangeListeners);
   }
 
-  switcherProvider = {
-    loadListeners: [],
-    popStateListeners: [],
-    hashChangeListeners: []
-  };
-
   handleLoadListeners = e => {
-    this.switcherProvider.loadListeners.forEach(({ fn }) => fn(e));
+    this._listenerContext.listeners.load.forEach(({ fn }) => fn(e));
   };
 
   handlePopStateListeners = e => {
-    this.switcherProvider.popStateListeners.forEach(({ fn }) => fn(e));
+    this._listenerContext.listeners.popState.forEach(({ fn }) => fn(e));
   };
 
   handleHashChangeListeners = e => {
-    this.switcherProvider.hashChangeListeners.forEach(({ fn }) => fn(e));
+    this._listenerContext.listeners.hashChange.forEach(({ fn }) => fn(e));
   };
 
   render() {
     if (Children.count(this.props.children) > 1) {
-      return <span className="switcher-provider">{this.props.children}</span>;
+      return (
+        <Provider value={this._listenerContext}>
+          <span className="switcher-provider">{this.props.children}</span>
+        </Provider>
+      );
     } else {
-      return this.props.children;
+      return (
+        <Provider value={this._listenerContext}>{this.props.children}</Provider>
+      );
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-export default from './Switcher';
+export default from './SwitcherConsumer';
 export SwitcherProvider from './SwitcherProvider';

--- a/src/listenerContext.js
+++ b/src/listenerContext.js
@@ -1,0 +1,31 @@
+import { createContext } from 'react';
+
+function createListenerContext(usingProvider) {
+  const listeners = {
+    load: [],
+    popState: [],
+    hashChange: []
+  };
+
+  return {
+    usingProvider,
+    listeners,
+    addLoadListener: ({ id, fn }) => listeners.load.push({ id, fn }),
+    addPopStateListener: ({ id, fn }) => listeners.popState.push({ id, fn }),
+    addHashChangeListener: ({ id, fn }) =>
+      listeners.hashChange.push({ id, fn }),
+    removeListeners: removeId => {
+      listeners.load = listeners.load.filter(({ id }) => id !== removeId);
+      listeners.popState = listeners.popState.filter(
+        ({ id }) => id !== removeId
+      );
+      listeners.hashChange = listeners.hashChange.filter(
+        ({ id }) => id !== removeId
+      );
+    }
+  };
+}
+
+const { Provider, Consumer } = createContext(createListenerContext(false));
+
+export { createListenerContext, Provider, Consumer };

--- a/test/SwitcherProvider_test.js
+++ b/test/SwitcherProvider_test.js
@@ -34,15 +34,15 @@ describe('SwitcherProvider', () => {
     const listenerId = innerSwitcher.instance()._id;
     const instance = component.instance();
 
-    expect(instance.switcherProvider.loadListeners.length).toEqual(2);
-    expect(instance.switcherProvider.hashChangeListeners.length).toEqual(2);
+    expect(instance._listenerContext.listeners.load.length).toEqual(2);
+    expect(instance._listenerContext.listeners.hashChange.length).toEqual(2);
     expect(
-      instance.switcherProvider.loadListeners
+      instance._listenerContext.listeners.load
         .map(({ id }) => id)
         .indexOf(listenerId)
     ).not.toEqual(-1);
     expect(
-      instance.switcherProvider.hashChangeListeners
+      instance._listenerContext.listeners.hashChange
         .map(({ id }) => id)
         .indexOf(listenerId)
     ).not.toEqual(-1);
@@ -52,15 +52,16 @@ describe('SwitcherProvider', () => {
     // trigger hash change manually
     component.instance().handleHashChangeListeners();
     component.update();
-    expect(instance.switcherProvider.loadListeners.length).toEqual(1);
-    expect(instance.switcherProvider.hashChangeListeners.length).toEqual(1);
+    console.log('HERE');
+    expect(instance._listenerContext.listeners.load.length).toEqual(1);
+    expect(instance._listenerContext.listeners.hashChange.length).toEqual(1);
     expect(
-      instance.switcherProvider.loadListeners
+      instance._listenerContext.listeners.load
         .map(({ id }) => id)
         .indexOf(listenerId)
     ).toEqual(-1);
     expect(
-      instance.switcherProvider.hashChangeListeners
+      instance._listenerContext.listeners.hashChange
         .map(({ id }) => id)
         .indexOf(listenerId)
     ).toEqual(-1);

--- a/test/Switcher_test.js
+++ b/test/Switcher_test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import PropTypes from 'prop-types';
 import sinon from 'sinon';
-import Switcher from '../src';
+import Switcher from '../src/Switcher';
 import * as helpers from '../src/helpers';
 
 describe('Switcher', () => {
@@ -11,6 +11,7 @@ describe('Switcher', () => {
       let switcher;
       beforeEach(() => {
         switcher = renderComponent(<div path="/">Home</div>);
+        console.log(switcher);
         console.log(switcher.html());
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4866,7 +4866,7 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.0.0:
+react-dom@^16.3.0:
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.5.2.tgz#b69ee47aa20bab5327b2b9d7c1fe2a30f2cfa9d7"
   integrity sha512-RC8LDw8feuZOHVgzEf7f+cxBr/DnKdqp56VU0lAs1f4UfKc4cU8wU4fTq/mgnvynLQo8OtlPC19NUFh/zjZPuA==
@@ -4881,7 +4881,7 @@ react-is@^16.5.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.2.tgz#e2a7b7c3f5d48062eb769fcb123505eb928722e3"
   integrity sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ==
 
-react-test-renderer@^16.0.0, react-test-renderer@^16.0.0-0:
+react-test-renderer@^16.0.0-0, react-test-renderer@^16.3.0:
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.5.2.tgz#92e9d2c6f763b9821b2e0b22f994ee675068b5ae"
   integrity sha512-AGbJYbCVx1J6jdUgI4s0hNp+9LxlgzKvXl0ROA3DHTrtjAr00Po1RhDZ/eAq2VC/ww8AHgpDXULh5V2rhEqqJg==
@@ -4891,7 +4891,7 @@ react-test-renderer@^16.0.0, react-test-renderer@^16.0.0-0:
     react-is "^16.5.2"
     schedule "^0.5.0"
 
-react@^16.0.0:
+react@^16.3.0:
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/react/-/react-16.5.2.tgz#19f6b444ed139baa45609eee6dc3d318b3895d42"
   integrity sha512-FDCSVd3DjVTmbEAjUNX6FgfAmQ+ypJfHUsqUJOYNCBUp1h8lqmtC+0mXJ+JjsWx4KAVTkk1vKd1hLQPvEviSuw==


### PR DESCRIPTION
This updates the usage of React APIs based on changes from 16.3. We will need to release a new major version with these changes as it will require `^16.3` to work properly.

- [x] Update context API
- [ ] Remove deprecated lifecycle methods
- [ ] Cleanup / Refactor